### PR TITLE
317 NHL/MLB Fixed Updater and MySettings to refer to project instead of common library

### DIFF
--- a/MLBAMGames.Library/AssemblyInfo.vb
+++ b/MLBAMGames.Library/AssemblyInfo.vb
@@ -2,7 +2,7 @@
 
 Public Class AssemblyInfo
     Public Shared Function IsNewerVersionThanCurrent(name As String, appFullPath As String) As Boolean
-        Dim m As Match = Regex.Match(name, "v(\.)?((?:\d+\.)*\d+?)")
+        Dim m As Match = Regex.Match(name, "v?(\.)?((?:\d+\.)*\d+?)")
         Dim version = m.Groups(m.Groups.Count - 1)
 
         If version.Success Then

--- a/MLBAMGames.Library/CustomExceptions.vb
+++ b/MLBAMGames.Library/CustomExceptions.vb
@@ -4,4 +4,12 @@
     Public Sub New()
     End Sub
 
+    Public Sub New(message As String)
+        MyBase.New(message)
+    End Sub
+
+    Public Sub New(message As String, inner As Exception)
+        MyBase.New(message, inner)
+    End Sub
+
 End Class

--- a/MLBAMGames.Library/GitHubAPI.vb
+++ b/MLBAMGames.Library/GitHubAPI.vb
@@ -8,9 +8,7 @@ Imports Newtonsoft.Json
 Public Class GitHubAPI
 
     Private Shared ReadOnly Property _regexVersion As Regex = New Regex($"(\d+\.)(\d+\.)?(\d+\.)?(\*|\d+)")
-    Private Shared ReadOnly Property _regexTag As Regex = New Regex($"[^0-9.]")
-    Private Shared ReadOnly Property _project As String = Assembly.GetCallingAssembly().GetName().Name
-    Private Shared ReadOnly Property _repoLink As String = $"https://api.github.com/repos/MLBAMGames/{_project}"
+    Private Shared ReadOnly Property _repoLink As String = $"https://api.github.com/repos/MLBAMGames/{Parameters.AssemblyName.Name}"
 
     Public Shared Async Function GetVersion() As Task
         Dim request = GetGitHubApiRequest($"{_repoLink}/releases/latest")
@@ -27,7 +25,7 @@ Public Class GitHubAPI
         If Not _regexVersion.IsMatch(versionTag) Then Return
 
         Dim gitHubTagVersion = New Version(versionTag)
-        Dim assemblyVersion = Assembly.GetExecutingAssembly().GetName().Version
+        Dim assemblyVersion = Parameters.AssemblyName.Version
 
         If gitHubTagVersion <= assemblyVersion Then Return
 
@@ -46,8 +44,7 @@ Public Class GitHubAPI
         Dim dialogResult = Instance.Form.MsgBox(
                 dialogMessage,
                 dialogTitle,
-                MessageBoxButtons.OKCancel,
-                MessageBoxIcon.Information)
+                MessageBoxButtons.OKCancel)
 
         If dialogResult = DialogResult.OK Then
             Update()
@@ -75,8 +72,7 @@ Public Class GitHubAPI
         Dim dialogResult = Instance.Form.MsgBox(
                 dialogMessage,
                 Lang.RmText.GetString("msgAnnouncement"),
-                MessageBoxButtons.OK,
-                MessageBoxIcon.Information)
+                MessageBoxButtons.OK)
     End Function
 
     Private Shared Function GetGitHubApiRequest(url As String) As HttpWebRequest
@@ -100,11 +96,11 @@ Public Class GitHubAPI
     End Function
 
     Private Shared Function ParseTagToVersionString(tag As String) As String
-        Return If(String.IsNullOrEmpty(tag), String.Empty, _regexTag.Replace(tag, String.Empty))
+        Return If(String.IsNullOrEmpty(tag), String.Empty, New Regex("\d+(\.\d+){0,3}").Match(tag)?.Value)
     End Function
 
     Public Shared Sub Update()
-        Process.Start(New ProcessStartInfo(Application.StartupPath + "/Updater/Updater.exe"))
+        Process.Start(New ProcessStartInfo(Parameters.StartupPath + "/updater/Updater.exe"))
         Application.Exit()
     End Sub
 

--- a/MLBAMGames.Library/IMLBAMForm.vb
+++ b/MLBAMGames.Library/IMLBAMForm.vb
@@ -68,6 +68,6 @@ Public Interface IMLBAMForm
 #Region "Methods"
     Function GetSetting(name As String) As Object
     Sub SetSetting(name As String, value As Object)
-    Function MsgBox(message As String, title As String, buttons As MessageBoxButtons, type As MessageBoxIcon) As DialogResult
+    Function MsgBox(message As String, title As String, buttons As MessageBoxButtons, Optional type As MessageBoxIcon? = Nothing) As DialogResult
 #End Region
 End Interface

--- a/MLBAMGames.Library/ImageFetcher.vb
+++ b/MLBAMGames.Library/ImageFetcher.vb
@@ -7,7 +7,7 @@ Public Class ImageFetcher
     Public Shared Function GetEmbeddedImage(fileName As String) As Image
         Dim image As Image = Nothing
         Dim assembly As Assembly = Assembly.GetCallingAssembly()
-        Using s As Stream = assembly.GetManifestResourceStream($"{assembly.GetName().Name}.{fileName.ToLower()}.png")
+        Using s As Stream = assembly.GetManifestResourceStream($"{Parameters.AssemblyName.Name}.{fileName.ToLower()}.png")
             If s Is Nothing Then Return Nothing
             s.Position = 0
             image = Image.FromStream(s)
@@ -20,7 +20,7 @@ Public Class ImageFetcher
 #If DEBUG Then
         Dim image As Bitmap = Nothing
         Dim assembly As Assembly = Assembly.GetCallingAssembly()
-        Using s As Stream = assembly.GetManifestResourceStream($"{assembly.GetName().Name}.{fileName.ToLower()}.svg")
+        Using s As Stream = assembly.GetManifestResourceStream($"{Parameters.AssemblyName.Name}.{fileName.ToLower()}.svg")
             If s Is Nothing Then Return Nothing
             s.Position = 0
             image = (SvgDocument.Open(Of SvgDocument)(s)).Draw()

--- a/MLBAMGames.Library/Parameters.vb
+++ b/MLBAMGames.Library/Parameters.vb
@@ -1,4 +1,4 @@
-﻿Imports MLBAMGames.Library.API
+﻿Imports System.Reflection
 
 Public Class Parameters
     Public Const ResizeBorderWidth As Integer = 8
@@ -27,6 +27,7 @@ Public Class Parameters
     Public Shared Property SpnStreamingVisible As Boolean = False
 
     Public Shared Property StartupPath As String = Nothing
+    Public Shared Property AssemblyName As AssemblyName = Nothing
 
     Public Shared Property Tips As New Dictionary(Of Integer, String)
     Public Shared Property WatchArgsParams As GameWatchArgumentsParameters = New GameWatchArgumentsParameters

--- a/MLBAMGames.Library/Updater.vb
+++ b/MLBAMGames.Library/Updater.vb
@@ -9,10 +9,9 @@ Public Class Updater
     Public Shared UpdaterExtractedContentDirectoryPath = $"{UpdaterExtractedTempDirectoryPath}\{UPDATER_DIRECTORY}"
     Public Shared UpdaterDirectoryPath = $"{ProjectDirectory}{UPDATER_DIRECTORY}"
 
-    Public Shared Sub UpgradeSettings()
+    Public Shared Sub UpgradeSettings(UpgradeSettings As Action)
         If Directory.Exists(UpdaterExtractedContentDirectoryPath) Then
-            My.Settings.Upgrade()
-            My.Settings.Save()
+            UpgradeSettings()
             UpdateDirectoryContent()
         End If
     End Sub

--- a/MLBAMGames.Library/Web.vb
+++ b/MLBAMGames.Library/Web.vb
@@ -27,6 +27,7 @@ Public Class Web
     End Function
 
     Public Shared Function SetHttpWebRequest(address As String) As HttpWebRequest
+        ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12
         Dim defaultHttpWebRequest = CType(WebRequest.Create(New Uri(address)), HttpWebRequest)
         defaultHttpWebRequest.UserAgent = UserAgent
         defaultHttpWebRequest.Method = WebRequestMethods.Http.Head

--- a/MLBGames.Updater/GitHubAPI.vb
+++ b/MLBGames.Updater/GitHubAPI.vb
@@ -8,7 +8,7 @@ Imports MLBAMGames.Library.GitHub
 
 Public Class GitHubAPI
 
-    Public Const API_LATEST_RELEASES_LINK As String = "https://api.github.com/repos/MBLAMGames/MLBGames/releases"
+    Public Const API_LATEST_RELEASES_LINK As String = "https://api.github.com/repos/MLBAMGames/MLBGames/releases"
     Public Const LATEST_RELEASE_LINK As String = "https://github.com/MLBAMGames/MLBGames/releases/latest"
 
     Public Shared Async Function GetReleases() As Task(Of Release())
@@ -35,10 +35,10 @@ Public Class GitHubAPI
     End Function
 
     Public Shared Function GetZipAssetFromRelease(release As Release) As Asset
-        Dim asset = release.assets.Where(Function(a) Regex.IsMatch(a.name, "^NHLGames(-|\.)(v?)(\.)?\d+(\.\d+)?(\.\d+)?(-simplified)?.zip$")).FirstOrDefault()
+        Dim asset = release.assets.Where(Function(a) Regex.IsMatch(a.name, "^MLBGames(-|\.)(v?)(\.)?\d+(\.\d+){0,3}?(-simplified)?.zip$")).FirstOrDefault()
         If asset Is Nothing Then
             Console.WriteLine("This Release did not have any suitable asset to download. Try again later.")
-            Throw New ReleaseAssetNotFoundException()
+            Throw New ReleaseAssetNotFoundException("This Release did not have any suitable asset to download. Try again later.")
         Else
             Console.WriteLine("Release asset found: {0}", asset.name)
         End If

--- a/MLBGames.Updater/My Project/Resources.Designer.vb
+++ b/MLBGames.Updater/My Project/Resources.Designer.vb
@@ -39,7 +39,7 @@ Namespace My.Resources
         Friend ReadOnly Property ResourceManager() As Global.System.Resources.ResourceManager
             Get
                 If Object.ReferenceEquals(resourceMan, Nothing) Then
-                    Dim temp As Global.System.Resources.ResourceManager = New Global.System.Resources.ResourceManager("NHLGames.Updater.Resources", GetType(Resources).Assembly)
+                    Dim temp As Global.System.Resources.ResourceManager = New Global.System.Resources.ResourceManager("MLBGames.Updater.Resources", GetType(Resources).Assembly)
                     resourceMan = temp
                 End If
                 Return resourceMan

--- a/MLBGames.Updater/Updater.vb
+++ b/MLBGames.Updater/Updater.vb
@@ -42,7 +42,7 @@ Public Class Updater
             Dim asset = GitHubAPI.GetZipAssetFromRelease(release)
             Return Await Web.DownloadFileAsync(asset.browser_download_url, release.tag_name)
         Catch ex As ReleaseAssetNotFoundException
-            Return String.Empty
+            Throw ex
         Catch ex As UnauthorizedAccessException
             Console.WriteLine($"Something went wrong during the download. Make sure it was not blocked by your Antivirus Software.")
             Console.WriteLine("Error Message: {0}", ex.Message)

--- a/MLBGames/MLBGamesMetro.vb
+++ b/MLBGames/MLBGamesMetro.vb
@@ -11,6 +11,7 @@ Imports MLBGames.Utilities
 Imports MLBGames.Controls
 Imports MLBAMGames.Library.Modules
 Imports MetroFramework
+Imports System.Reflection
 
 Public Class MLBGamesMetro
     Implements IMLBAMForm
@@ -21,7 +22,7 @@ Public Class MLBGamesMetro
         Application.SetUnhandledExceptionMode(UnhandledExceptionMode.CatchException)
         AddHandler AppDomain.CurrentDomain.UnhandledException, AddressOf CurrentDomain_UnhandledException
 
-        Updater.UpgradeSettings()
+        Updater.UpgradeSettings(New Action(AddressOf UpgradeSettings))
 
         Lang.FrenchRmText = French.ResourceManager
         Lang.EnglishRmText = English.ResourceManager
@@ -29,6 +30,7 @@ Public Class MLBGamesMetro
 
         Parameters.IsDarkMode = My.Settings.UseDarkMode
         Parameters.StartupPath = Application.StartupPath
+        Parameters.AssemblyName = Assembly.GetExecutingAssembly.GetName()
         Parameters.DomainNames = {"playback.svcs.mlb.com", "mlb-ws-mf.media.mlb.com"}
 
         Dim form As New MLBGamesMetro()
@@ -118,7 +120,7 @@ Public Class MLBGamesMetro
                                        End Sub)
     End Sub
 
-    Public Function MsgBox(message As String, title As String, buttons As MessageBoxButtons, type As MessageBoxIcon) As DialogResult Implements IMLBAMForm.MsgBox
+    Public Function MsgBox(message As String, title As String, buttons As MessageBoxButtons, Optional type As MessageBoxIcon? = Nothing) As DialogResult Implements IMLBAMForm.MsgBox
         Dim dialogResult As New DialogResult
         If Parameters.MsgBoxVisible Then Return dialogResult
         Parameters.MsgBoxVisible = True
@@ -127,7 +129,7 @@ Public Class MLBGamesMetro
                                         message,
                                         title,
                                         buttons,
-                                        type)
+                                        If(type, MessageBoxIcon.Hand))
                                      Return True
                                  End Function)
         If type = MessageBoxIcon.Error Then
@@ -136,6 +138,11 @@ Public Class MLBGamesMetro
         Parameters.MsgBoxVisible = False
         Return dialogResult
     End Function
+
+    Private Shared Sub UpgradeSettings()
+        My.Settings.Upgrade()
+        My.Settings.Save()
+    End Sub
 
     Private Sub LoadStandings()
         cbSeasons.SetPropertyThreadSafe(Sub()
@@ -840,7 +847,7 @@ Public Class MLBGamesMetro
             Lang.RmText.GetString("msgAcceptToRestart"),
             Lang.RmText.GetString("lblDark"),
             MessageBoxButtons.YesNo,
-            MessageBoxIcon.Information) = DialogResult.Yes Then
+            MessageBoxIcon.Hand) = DialogResult.Yes Then
             RestartMLBGames()
         End If
         My.Settings.UseDarkMode = tgDarkMode.Checked
@@ -877,13 +884,14 @@ Public Class MLBGamesMetro
     End Sub
 
     Private Sub tgReset_CheckedChanged(sender As Object, e As EventArgs) Handles tgReset.CheckedChanged, flpCalendarPanel.VisibleChanged
+
         If tgReset.Checked = False Then Return
 
         If Instance.Form.MsgBox(
             Lang.RmText.GetString("msgAcceptToRestart"),
             Lang.RmText.GetString("lblReset"),
             MessageBoxButtons.YesNo,
-            MessageBoxIcon.Information) = DialogResult.Yes Then
+            MessageBoxIcon.Hand) = DialogResult.Yes Then
             My.Settings.Reset()
             My.Settings.Save()
             Dim x = My.Settings.LastBuildVersionSkipped

--- a/NHLGames.Updater/GitHubAPI.vb
+++ b/NHLGames.Updater/GitHubAPI.vb
@@ -35,10 +35,10 @@ Public Class GitHubAPI
     End Function
 
     Public Shared Function GetZipAssetFromRelease(release As Release) As Asset
-        Dim asset = release.assets.Where(Function(a) Regex.IsMatch(a.name, "^NHLGames(-|\.)(v?)(\.)?\d+(\.\d+)?(\.\d+)?(-simplified)?.zip$")).FirstOrDefault()
+        Dim asset = release.assets.Where(Function(a) Regex.IsMatch(a.name, "^NHLGames(-|\.)(v?)(\.)?\d+(\.\d+){0,3}?(-simplified)?.zip$")).FirstOrDefault()
         If asset Is Nothing Then
             Console.WriteLine("This Release did not have any suitable asset to download. Try again later.")
-            Throw New ReleaseAssetNotFoundException()
+            Throw New ReleaseAssetNotFoundException("This Release did not have any suitable asset to download. Try again later.")
         Else
             Console.WriteLine("Release asset found: {0}", asset.name)
         End If

--- a/NHLGames.Updater/Updater.vb
+++ b/NHLGames.Updater/Updater.vb
@@ -42,7 +42,7 @@ Public Class Updater
             Dim asset = GitHubAPI.GetZipAssetFromRelease(release)
             Return Await Web.DownloadFileAsync(asset.browser_download_url, release.tag_name)
         Catch ex As ReleaseAssetNotFoundException
-            Return String.Empty
+            Throw ex
         Catch ex As UnauthorizedAccessException
             Console.WriteLine($"Something went wrong during the download. Make sure it was not blocked by your Antivirus Software.")
             Console.WriteLine("Error Message: {0}", ex.Message)

--- a/NHLGames/NHLGamesMetro.vb
+++ b/NHLGames/NHLGamesMetro.vb
@@ -11,6 +11,7 @@ Imports NHLGames.Utilities
 Imports NHLGames.Controls
 Imports MLBAMGames.Library.Modules
 Imports MetroFramework
+Imports System.Reflection
 
 Public Class NHLGamesMetro
     Implements IMLBAMForm
@@ -21,7 +22,7 @@ Public Class NHLGamesMetro
         Application.SetUnhandledExceptionMode(UnhandledExceptionMode.CatchException)
         AddHandler AppDomain.CurrentDomain.UnhandledException, AddressOf CurrentDomain_UnhandledException
 
-        Updater.UpgradeSettings()
+        Updater.UpgradeSettings(New Action(AddressOf UpgradeSettings))
 
         Lang.FrenchRmText = French.ResourceManager
         Lang.EnglishRmText = English.ResourceManager
@@ -29,6 +30,7 @@ Public Class NHLGamesMetro
 
         Parameters.IsDarkMode = My.Settings.UseDarkMode
         Parameters.StartupPath = Application.StartupPath
+        Parameters.AssemblyName = Assembly.GetExecutingAssembly.GetName()
         Parameters.DomainNames = {"mf.svc.nhl.com"}
 
         Dim form As New NHLGamesMetro()
@@ -113,7 +115,7 @@ Public Class NHLGamesMetro
 
     End Sub
 
-    Public Function MsgBox(message As String, title As String, buttons As MessageBoxButtons, type As MessageBoxIcon) As DialogResult Implements IMLBAMForm.MsgBox
+    Public Function MsgBox(message As String, title As String, buttons As MessageBoxButtons, Optional type As MessageBoxIcon? = Nothing) As DialogResult Implements IMLBAMForm.MsgBox
         Dim DialogResult As New DialogResult
         If Parameters.MsgBoxVisible Then Return DialogResult
         Parameters.MsgBoxVisible = True
@@ -122,7 +124,7 @@ Public Class NHLGamesMetro
                                         message,
                                         title,
                                         buttons,
-                                        type)
+                                        If(type, MessageBoxIcon.Information))
                                      Return True
                                  End Function)
         If type = MessageBoxIcon.Error Then
@@ -131,6 +133,11 @@ Public Class NHLGamesMetro
         Parameters.MsgBoxVisible = False
         Return DialogResult
     End Function
+
+    Private Shared Sub UpgradeSettings()
+        My.Settings.Upgrade()
+        My.Settings.Save()
+    End Sub
 
     Private Sub LoadStandings()
         cbSeasons.SetPropertyThreadSafe(Sub()
@@ -891,7 +898,7 @@ Public Class NHLGamesMetro
         _writeToConsoleSettingToggleChanged(lblPlayerArgs.Text, tgPlayer.Checked)
     End Sub
 
-    Private Sub tgReset_CheckedChanged(sender As Object, e As EventArgs) Handles tgReset.CheckedChanged
+    Private Sub tgReset_CheckedChanged(sender As Object, e As EventArgs) Handles tgReset.
         If tgReset.Checked = False Then Return
 
         If Instance.Form.MsgBox(


### PR DESCRIPTION
close https://github.com/MLBAMGames/NHLGames/issues/317

Users that downloaded the past release won't be able to get releases or annoucements anymore, since the repo it looks for is "MLBAMGames.Library" (name of the common library project in MLBAMGames repo). So I created a new repo named like so, so people that have the bug will be able to upgrade to the newest version. After releasing the new version for both apps, we should post an issue with the label `announcement` to this new repository https://github.com/MLBAMGames/MLBAMGames.Library/issues