### PR TITLE
Fix standings not being loaded when games are loaded

### DIFF
--- a/NHLGames/Controls/GameControl.vb
+++ b/NHLGames/Controls/GameControl.vb
@@ -183,7 +183,7 @@ Namespace Controls
             lblHomeTeam.Visible = showTeamCityAbr
             lblAwayTeam.Visible = showTeamCityAbr
 
-            If showStanding Then
+            If showStanding And API.Seasons.CurrentSeason IsNot Nothing Then
                 Adorner.AddBadgeTo(picAway, Standing.GetCurrentStandings(StandingTypeEnum.League, API.Seasons.CurrentSeason.seasonId, _game.AwayTeam))
                 Adorner.AddBadgeTo(picHome, Standing.GetCurrentStandings(StandingTypeEnum.League, API.Seasons.CurrentSeason.seasonId, _game.HomeTeam))
             Else

--- a/NHLGames/NHLGamesMetro.vb
+++ b/NHLGames/NHLGamesMetro.vb
@@ -83,10 +83,11 @@ Public Class NHLGamesMetro
         ResumeLayout(True)
 
         tmr.Enabled = True
-        Await LoadGames(CalendarControl.GameDate)
 
         LoadTeamsName()
         LoadStandings()
+
+        Await LoadGames(CalendarControl.GameDate)
     End Sub
 
     Private Async Function LoadGames(gameDate As Date) As Task


### PR DESCRIPTION
I was hitting an exception trying to get the current season to show
standings when standings were enabled in the settings. `CurrentSeason` is
set as a side effect of the `GetAllNHLSeasons()` getter (which feels
brittle) and since games were loaded before standings, the `CurrentSeason`
was always unset.

This means startup takes a little longer before games are shown, of
course, but it doesn't do much good to try showing games that are going
to end up throwing an exception anyway (if users have Standing Rank
enabled).