### PR TITLE
Fix exception populating games with "Standing Rank" enabled

### DIFF
--- a/MLBAMGames.Library/Standings/Standing.vb
+++ b/MLBAMGames.Library/Standings/Standing.vb
@@ -29,6 +29,10 @@ Namespace Standings
         Public Shared Function GetCurrentStandings(ByVal standingType As StandingTypeEnum, ByVal season As String, ByVal teamName As String) As String
 
             Dim standing As Standing = GetCurrentStandings(standingType, season)
+            If (standing?.records?.FirstOrDefault()?.teamRecords Is Nothing) Then
+                Return 0
+            End If
+
             Dim teamRecord As TeamRecord = standing.records.First().teamRecords.FirstOrDefault(Function(n) n.team.name.Contains(teamName))
 
             If (standingType = StandingTypeEnum.League) Then

--- a/NHLGames/Controls/GameControl.vb
+++ b/NHLGames/Controls/GameControl.vb
@@ -184,8 +184,18 @@ Namespace Controls
             lblAwayTeam.Visible = showTeamCityAbr
 
             If showStanding Then
-                Adorner.AddBadgeTo(picAway, Standing.GetCurrentStandings(StandingTypeEnum.League, API.Seasons.CurrentSeason.seasonId, _game.AwayTeam))
-                Adorner.AddBadgeTo(picHome, Standing.GetCurrentStandings(StandingTypeEnum.League, API.Seasons.CurrentSeason.seasonId, _game.HomeTeam))
+                Dim standingBadge = Sub(pic, team)
+                                        Dim teamStanding = Standing.GetCurrentStandings(StandingTypeEnum.League, API.Seasons.CurrentSeason.seasonId, team)
+
+                                        If Not String.IsNullOrEmpty(teamStanding) AndAlso teamStanding <> "0" Then
+                                            Adorner.AddBadgeTo(pic, teamStanding)
+                                        Else
+                                            Adorner.RemoveBadgeFrom(pic)
+                                        End If
+                                    End Sub
+
+                standingBadge(picAway, _game.AwayTeam)
+                standingBadge(picHome, _game.HomeTeam)
             Else
                 Adorner.RemoveBadgeFrom(picAway)
                 Adorner.RemoveBadgeFrom(picHome)


### PR DESCRIPTION
If Standing Rank is enabled but no records are available for a team, an
exception is generated and the app will not show any games. This
protects against that by catching when there are no records to show
standings for.

After fixing that, I noticed all teams were populating with a standing
of "00". So I also added detection for when no standing is known for a
team, which removes the badge altogether instead of showing everyone
with a standing of 00 before the season starts.